### PR TITLE
check connectionString.Certificate like keesschollaart81 version.

### DIFF
--- a/src/CaseOnline.Azure.WebJobs.Extensions.Mqtt/Bindings/MqttConfigurationParser.cs
+++ b/src/CaseOnline.Azure.WebJobs.Extensions.Mqtt/Bindings/MqttConfigurationParser.cs
@@ -84,9 +84,12 @@ public class MqttConfigurationParser : IMqttConfigurationParser
         if (connectionString.Tls)
         {
             var certificates = new List<X509Certificate2>();
-            using (var cert = new X509Certificate2(connectionString.Certificate))
+            if (connectionString.Certificate != null)
             {
-                certificates.Add(cert);
+                using (var cert = new X509Certificate2(connectionString.Certificate))
+                {
+                    certificates.Add(cert);
+                }
             }
 
             mqttClientOptionsBuilder = mqttClientOptionsBuilder.WithTls(new MqttClientOptionsBuilderTlsParameters


### PR DESCRIPTION
I want to use "CaseOnline.Azure.WebJobs.Extensions.Mqtt.**net6**" but after deployment I get the error.
- Case1 without Tls setting:
	- "System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host.".
- Case2 with Certificate setting:
	- "System.Security.Cryptography.X509Certificates: The system cannot find the path specified.".
	- It works in the local environment, but an error occurs when deploying to AzureFunctions.
	
"CaseOnline.Azure.WebJobs.Extensions.Mqtt" was available with Tls=true and No-Certificate setting.
I would like to change the same.